### PR TITLE
Don't call logging.basicConfig() in library code

### DIFF
--- a/examples/echobot.py
+++ b/examples/echobot.py
@@ -2,21 +2,36 @@
 
 '''Simple Bot to reply Telegram messages'''
 
+import logging
 import telegram
 import time
 
-# Telegram Bot Authorization Token
-bot = telegram.Bot('TOKEN')
 
-# This will be our global variable to keep the latest update_id when requesting
-# for updates. It starts with the latest update_id if available.
-try:
-    LAST_UPDATE_ID = bot.getUpdates()[-1].update_id
-except IndexError:
-    LAST_UPDATE_ID = None
+LAST_UPDATE_ID = None
 
 
-def echo():
+def main():
+    global LAST_UPDATE_ID
+
+    logging.basicConfig(
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    # Telegram Bot Authorization Token
+    bot = telegram.Bot('TOKEN')
+
+    # This will be our global variable to keep the latest update_id when requesting
+    # for updates. It starts with the latest update_id if available.
+    try:
+        LAST_UPDATE_ID = bot.getUpdates()[-1].update_id
+    except IndexError:
+        LAST_UPDATE_ID = None
+
+    while True:
+        echo(bot)
+        time.sleep(3)
+
+
+def echo(bot):
     global LAST_UPDATE_ID
 
     # Request updates from last updated_id
@@ -36,6 +51,4 @@ def echo():
 
 
 if __name__ == '__main__':
-    while True:
-        echo()
-        time.sleep(3)
+    main()

--- a/examples/roboed.py
+++ b/examples/roboed.py
@@ -5,14 +5,16 @@
 
 __author__ = 'leandrotoledodesouza@gmail.com'
 
+import logging
 import telegram
 import urllib
 
 
 def main():
+    logging.basicConfig(
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     bot = telegram.Bot('TOKEN')  # Telegram Bot Authorization Token
 
-    global LAST_UPDATE_ID
     LAST_UPDATE_ID = bot.getUpdates()[-1].update_id  # Get lastest update
 
     while True:

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -18,9 +18,6 @@ import logging
 from telegram import (User, Message, Update, UserProfilePhotos, TelegramError,
                       ReplyMarkup, InputFile, TelegramObject)
 
-logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
 
 class Bot(TelegramObject):
 

--- a/telegram_test.py
+++ b/telegram_test.py
@@ -1,6 +1,9 @@
+import logging
 import unittest
 from tests.test_bot import BotTest
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     testsuite = unittest.TestLoader().loadTestsFromTestCase(BotTest)
     unittest.TextTestRunner(verbosity=1).run(testsuite)


### PR DESCRIPTION
Logging should be configured by the application, not by libraries it
uses. Libraries should just get a logger and log to it.

Fixes #21 

For another concrete problem caused by calling `logging.basicConfig()` in the library, `import telegram` changes the meaning of the following program:

```python
import logging
import telegram

log = logging.getLogger(__name__)

if __name__ == '__main__':
    logging.basicConfig(level='DEBUG')
    log.debug("this should be printed, but will not be "
        "unless you comment out 'import telegram'")
```