### PR TITLE
add remaining chat actions

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -530,8 +530,8 @@ class Bot(TelegramObject):
             is about to receive:
             - ChatAction.TYPING for text messages,
             - ChatAction.UPLOAD_PHOTO for photos,
-            - ChatAction.UPLOAD_VIDEO or upload_video for videos,
-            - ChatAction.UPLOAD_AUDIO or upload_audio for audio files,
+            - ChatAction.UPLOAD_VIDEO for videos,
+            - ChatAction.UPLOAD_AUDIO for audio files,
             - ChatAction.UPLOAD_DOCUMENT for general files,
             - ChatAction.FIND_LOCATION for location data.
         """

--- a/telegram/chataction.py
+++ b/telegram/chataction.py
@@ -20,7 +20,9 @@
 class ChatAction(object):
     TYPING = 'typing'
     UPLOAD_PHOTO = 'upload_photo'
-    RECORD_VIDEO = 'upload_video'
-    RECORD_AUDIO = 'upload_audio'
+    RECORD_VIDEO = 'record_video'
+    UPLOAD_VIDEO = 'upload_video'
+    RECORD_AUDIO = 'record_audio'
+    UPLOAD_AUDIO = 'upload_audio'
     UPLOAD_DOCUMENT = 'upload_document'
     FIND_LOCATION = 'find_location'


### PR DESCRIPTION
The ChatActions from the doc weren't there. The telegram API supports the "record" and "upload" messages, but the client sees the same message for both (at least now on Android).