### PR TITLE
Decode Emoji byte strings into unicode strings if using Python 3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `ErgoZ Riftbit Vaper <https://github.com/ergoz>`_
 - `franciscod <https://github.com/franciscod>`_
 - `JASON0916 <https://github.com/JASON0916>`_
+- `jh0ker <https://github.com/jh0ker>`_
 - `JRoot3D <https://github.com/JRoot3D>`_
 - `macrojames <https://github.com/macrojames>`_
 - `njittam <https://github.com/njittam>`_

--- a/telegram/emoji.py
+++ b/telegram/emoji.py
@@ -36,6 +36,7 @@ def call_decode_byte_strings(cls):
     cls._decode_byte_strings()
     return cls
 
+@call_decode_byte_strings
 class Emoji(object):
     """This object represents an Emoji."""
 

--- a/telegram/emoji.py
+++ b/telegram/emoji.py
@@ -20,9 +20,41 @@
 
 """This module contains a object that represents an Emoji"""
 
+import sys
+
+def call_decode_byte_strings(cls):
+    """ 
+    Calls the _decode_byte_strings function of the created class
+    
+    Args:
+        cls (Class):
+    
+    Returns:
+        Class:
+    """
+    
+    cls._decode_byte_strings()
+    return cls
 
 class Emoji(object):
     """This object represents an Emoji."""
+
+    @classmethod
+    def _decode_byte_strings(cls):
+        """
+        Decodes the Emojis into unicode strings if using Python 3
+        
+        Args:
+            cls (Class):
+            
+        Returns:
+        """
+        
+        if sys.version_info.major is 3:
+            emojis = filter(lambda attr : type(getattr(cls, attr)) is bytes, 
+                     dir(cls))
+            for var in emojis:
+                setattr(cls, var, getattr(cls, var).decode('utf-8'))
 
     GRINNING_FACE_WITH_SMILING_EYES = b'\xF0\x9F\x98\x81'
     FACE_WITH_TEARS_OF_JOY = b'\xF0\x9F\x98\x82'

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -134,7 +134,7 @@ class Message(TelegramObject):
         if not data:
             return None
 
-        data['from_user'] = User.de_json(data['from'])
+        data['from_user'] = User.de_json(data.get('from'))
         data['date'] = datetime.fromtimestamp(data['date'])
         if 'first_name' in data.get('chat', ''):
             data['chat'] = User.de_json(data.get('chat'))

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015 Leandro Toledo de Souza <leandrotoeldodesouza@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+"""This module contains a object that represents Tests for Telegram Emoji"""
+
+import os
+import unittest
+import sys
+sys.path.append('.')
+
+import telegram
+from telegram.emoji import Emoji
+from tests.base import BaseTest
+
+
+class EmojiTest(BaseTest, unittest.TestCase):
+    """This object represents Tests for Telegram Emoji."""
+
+    def test_emoji(self):
+        """Test Emoji class"""
+        print('Testing Emoji class')
+        
+        for attr in dir(Emoji):
+            if attr[0] != '_':  # TODO: dirty way to filter out functions
+                self.assertTrue(type(getattr(Emoji, attr)) is str)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I used a class decorator to call a function upon class creation, that decodes every class attribute of the type 'bytes' into 'str' if sys.version_info.major == 3

Fix for https://github.com/leandrotoledo/python-telegram-bot/issues/80