### PR TITLE
Added usage example to sendPhoto docstring

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -292,11 +292,11 @@ class Bot(TelegramObject):
           token = "TOKEN"
           bot = telegram.Bot(token=token)
 
-          # assuming at least one pending chat message is waiting a photo reply.
+          # assuming at least one pending chat message is waits a photo reply.
           chat_id = bot.getUpdates()[-1].message.chat.id
 
           # to send a photo from a URL
-          remote_photo_url = "https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png"
+          remote_photo_url = "http://www.example.com/image.png"
           bot.sendPhoto(chat_id=chat_id, photo=remote_photo_url)
 
           # to send a photo from the local disk

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -285,6 +285,24 @@ class Bot(TelegramObject):
 
         Returns:
           A telegram.Message instance representing the message posted.
+
+        Examples:
+
+          import telegram
+          token = "TOKEN
+          bot = telegram.Bot(token=token)
+
+          # assuming at least one pending chat message is waiting a photo reply.
+          chat_id = bot.getUpdates()[-1].message.chat.id
+
+          # to send a photo from a URL
+          remote_photo_url = "https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png"
+          bot.sendPhoto(chat_id=chat_id, photo=remote_photo_url)
+
+          # to send a photo from the local disk
+          local_photo_path = "/path/to/local/photo.jpg"
+          with open(local_photo_path, 'rb') as photo:
+            bot.sendPhoto(chat_id=chat_id, photo=photo)
         """
 
         url = '%s/sendPhoto' % self.base_url

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -289,7 +289,7 @@ class Bot(TelegramObject):
         Examples:
 
           import telegram
-          token = "TOKEN
+          token = "TOKEN"
           bot = telegram.Bot(token=token)
 
           # assuming at least one pending chat message is waiting a photo reply.


### PR DESCRIPTION
Hi,

I started using your telegram bot and quickly managed to create a nice bot. Groovy!
I didn't understand though how to use bot.sendPhoto to send a local file though. I ended up implementing it myself. I wanted to add my implementation to your library but ended up realizing you support this. The problem was lack of documentation, so my pull request is just an addition of examples I wrote.

Below is my suggested examples to add to the docstring. If you don't want to go through a pull request you can just copy and paste this. I really think better documentation like this would enable many more people to use your great library.

Thanks!
>g.

The suggested examples for the docstrings:
```python
        Examples:

          import telegram
          token = "TOKEN"
          bot = telegram.Bot(token=token)

          # assuming at least one pending chat message is waiting a photo reply.
          chat_id = bot.getUpdates()[-1].message.chat.id

          # to send a photo from a URL
          remote_photo_url = "https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png"
          bot.sendPhoto(chat_id=chat_id, photo=remote_photo_url)

          # to send a photo from the local disk
          local_photo_path = "/path/to/local/photo.jpg"
          with open(local_photo_path, 'rb') as photo:
              bot.sendPhoto(chat_id=chat_id, photo=photo)
```

Just for laughs, here's my implementation (which was an overkill, I now understand):
```python
import requests

def send_photo(bot, photo_file, chat_id, verbose=False, caption=None):
    token = bot.token
    endpoint = "https://api.telegram.org/bot%s/sendPhoto" % (token)
    data={"chat_id": chat_id}
    if caption is not None:
        data["caption"] = caption
    response = requests.post(endpoint, files=dict(photo=open(photo_file, 'rb')), data=data)
    if verbose:
        print response.status_code, response.reason
    return response
```